### PR TITLE
Strict Standards error correction

### DIFF
--- a/lib/ns_tmo_plugin.class.php
+++ b/lib/ns_tmo_plugin.class.php
@@ -107,7 +107,7 @@ class NS_TMO_Plugin {
 	/**
 	 *
 	*/
-	public function get_instance () {
+	public static function get_instance () {
 		
 		if (empty(self::$instance)) {
 			


### PR DESCRIPTION
get_instance is called statically, so make sure it is defined as a static function.

closes #3 
